### PR TITLE
Added PAX archive format support to minicoredumper to overcome core size limit of 8GB.

### DIFF
--- a/src/minicoredumper/prog_config.c
+++ b/src/minicoredumper/prog_config.c
@@ -184,6 +184,10 @@ static int read_prog_compression_config(struct json_object *root,
 			if (get_json_boolean(v, &cfg->core_in_tar) != 0)
 				return -1;
 
+		} else if (strcmp(n, "use_posix_for_tar") == 0) {
+			if (get_json_boolean(v, &cfg->using_posix_format) != 0)
+				return -1;
+
 		} else {
 			info("WARNING: ignoring unknown config item: %s", n);
 		}
@@ -692,6 +696,9 @@ static void set_config_defaults(struct prog_config *cfg)
 
 	/* for compression, pack in tarball */
 	cfg->core_in_tar = true;
+
+	/* use posix archive format */
+	cfg->using_posix_format = true;
 }
 
 int init_prog_config(struct config *cfg, const char *cfg_file)

--- a/src/minicoredumper/prog_config.h
+++ b/src/minicoredumper/prog_config.h
@@ -44,6 +44,7 @@ struct prog_config {
 	char *core_compressor;
 	char *core_compressor_ext;
 	bool core_in_tar;
+	bool using_posix_format;
 	bool core_compressed;
 	bool dump_fat_core;
 	bool dump_auxv_so_list;

--- a/src/minicoredumper/tar.h
+++ b/src/minicoredumper/tar.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Nutanix 2023. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#ifndef __TAR_H__
+#define __TAR_H__
+
+/* The size of a tar block */
+#define BLOCK_SIZE 512
+
+/* Structs for gnu tar format */
+struct sparse {
+    char offset[12];
+    char numbytes[12];
+};
+
+struct tar_header {
+    char name[100];              // 0-99
+    char mode[8];                // 100-107
+    char uid[8];                 // 108-115
+    char gid[8];                 // 116-123
+    char numbytes[12];           // 124-135
+    char mtime[12];              // 136-147
+    char checksum[8];            // 148-155
+    char type;                   // 156
+    char linkname[100];          // 157-256
+    char magic[6];               // 257-262
+    char version[2];             // 263-264
+    char username[32];           // 265-296
+    char groupname[32];          // 297-328
+    char dev_major[8];           // 329-336
+    char dev_minor[8];           // 337-344
+    char atime[12];              // 345-356
+    char ctime[12];              // 357-368
+    char multivolume_offset[12]; // 369-380
+    char longnames[4];           // 381-384
+    char pad0;                   // 385
+    struct sparse sparse_map[4]; // 386-481
+    char is_extended;            // 482
+    char filesize[12];           // 483-494
+    char pad1[17];               // 495-511
+};
+
+
+/* Structs for posix tar format */
+struct posix_header {
+    char name[100];     // 0-99
+    char mode[8];       // 100-107
+    char uid[8];        // 108-115
+    char gid[8];        // 116-123
+    char numbytes[12];  // 124-135
+    char mtime[12];     // 136-147
+    char checksum[8];   // 148-155
+    char type;          // 156
+    char linkname[100]; // 157-256
+    char magic[6];      // 257-262
+    char version[2];    // 263-264
+    char username[32];  // 265-296
+    char groupname[32]; // 297-328
+    char dev_major[8];  // 329-336
+    char dev_minor[8];  // 337-344
+    char prefix[155];   // 345-499
+    char pad[12];       // 500-511
+};
+
+struct posix_sparse_list_element {
+    off64_t offset;
+    off64_t num_bytes;
+    struct posix_sparse_list_element *next_element;
+};
+
+struct posix_sparse_list {
+    unsigned long int list_length;
+    struct posix_sparse_list_element *first_element;
+};
+
+#endif


### PR DESCRIPTION
PAX archive format is used to fix the below:

>     * Known problems:
> 
>         - If tar is active, core files larger than 8GB will be
>           truncated. If it is known that the core files will be >8GB and
>           the full core file is needed, tar must be disabled.

---
Summary
- minicoredumper-2.0.6 lacks support for archiving > 8GB dumps.
- patch adds support for larger cores using POSIX archive format.
- includes sparse file support with format '1.0'.

This change contain
- modified etc/generic.recept.json to include "use_posix_for_tar" key. (Below changes in minicoredumper-2.0.6/src)
- prog_config.c & prog_config.h : added recept json option "use_posix_for_tar" under the "compression" entry with default value "true".
- tar.h : contains the structs for gnu and posix tar archives.
- added some comments in corestripper.c
- major functions added to corestripper.c are
  - dump_compressed_posix_tar
  - write_pax_extended_entry
  - fill_name_in_pax_header
  - build_sparse_map_linked_list
- modified the below functions in corestripper.c for PAX format support
  - check_core_size
  - dump_compressed_core
  - dump_compressed_tar

References
- https://www.ibm.com/docs/en/zos/2.3.0?topic=ff-pax-format-pax-archives-special-header-summary-files
- https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html
- https://www.gnu.org/software/tar/manual/html_node/PAX-1.html#PAX-1