### PR TITLE
Fix cores truncated after 8gb

### DIFF
--- a/src/minicoredumper/corestripper.c
+++ b/src/minicoredumper/corestripper.c
@@ -52,14 +52,6 @@
 #define PTRACE_INTERRUPT 0x4207
 #endif
 
-/*
- * The ustar format only has 11 octal characters available for
- * specifying sizes and offsets. So the maximum value is:
- *
- *       077777777777 => 8589934591
- */
-#define USTAR_MAXVAL 8589934591
-
 static struct dump_info *global_di;
 static long PAGESZ;
 
@@ -1524,15 +1516,6 @@ int add_core_data(struct dump_info *di, off64_t dest_offset, size_t len,
 
 	end = start + len;
 
-	if (di->cfg->prog_config.core_in_tar &&
-	    di->cfg->prog_config.core_compressor &&
-	    (start > USTAR_MAXVAL || end > USTAR_MAXVAL)) {
-		info("core data too large for ustar format "
-		     "(0x%" PRIx64 "-0x%" PRIx64 "), dropping",
-		     start, end);
-		return EFBIG;
-	}
-
 	for (cur = di->core_file; cur && !done; cur = cur->next) {
 		if (end < cur->start) {
 			/* insert new block */
@@ -1648,26 +1631,6 @@ int add_core_data(struct dump_info *di, off64_t dest_offset, size_t len,
 }
 
 /*
- * In case the core file is packed into a tar, make sure the core file
- * size does not exceed the value limits of the ustar format.
- */
-static void check_core_size(struct dump_info *di)
-{
-	if (!di->cfg->prog_config.core_in_tar)
-		return;
-	if (!di->cfg->prog_config.core_compressor)
-		return;
-	if (di->core_file_size <= USTAR_MAXVAL)
-		return;
-
-	info("core is too large for ustar format (%" PRIu64 " bytes), "
-	     "truncating to %" PRIu64 " bytes",
-	     di->core_file_size, USTAR_MAXVAL);
-
-	di->core_file_size = USTAR_MAXVAL;
-}
-
-/*
  * Reads the ELF header from the large core file.
  * This header is dumped to the core.
  */
@@ -1742,7 +1705,6 @@ again:
 
 	/* make the core big enough to fit all vma areas */
 	di->core_file_size = di->vma_end;
-	check_core_size(di);
 
 	/* add empty core data to mark the size of the core file */
 	add_core_data(di, di->core_file_size, 0, di->elf_fd, 0);
@@ -3514,7 +3476,6 @@ static int add_dumplist_section(struct dump_info *di)
 	}
 
 	di->core_file_size = core_size;
-	check_core_size(di);
 
 	add_core_data(di, dump_offset, core_size - dump_offset,
 		      di->elf_fd, dump_offset);

--- a/src/minicoredumper/corestripper.c
+++ b/src/minicoredumper/corestripper.c
@@ -1152,6 +1152,9 @@ static int dump_zero_block_rest(int fd, size_t block_bytes_written)
 }
 
 
+/* All tar numeric fields are 12 bytes. */
+#define TAR_NUMBER_SIZE 12
+
 /*
  * ustar stores numeric fields as octal ASCII, right-justified and
  * zero-padded, with one byte reserved for a NUL (or space) terminator.
@@ -1161,18 +1164,26 @@ static int dump_zero_block_rest(int fd, size_t block_bytes_written)
 #define USTAR_MAXVAL (UINT64_C(077777777777))
 
 /*
- * Write val into a tar header numeric field of the given size, using ustar
- * octal encoding when the value fits and GNU tar's base-256 extension
- * otherwise. Both encodings are understood by "tar x" (GNU tar and
- * libarchive), including in the old-GNU sparse map.
+ * Write val into a 12-byte tar header numeric field, using octal when the
+ * value fits and GNU tar's base-256 extension otherwise. Both encodings
+ * are understood by "tar x" (GNU tar and libarchive), including in the
+ * old-GNU sparse map.
  */
-static void put_tar_number(char *field, size_t size, uint64_t val)
+#define put_tar_number(field, val) \
+	do { \
+		_Static_assert(sizeof(field) == TAR_NUMBER_SIZE, \
+			       "tar numeric field must be 12 bytes"); \
+		put_tar_number_impl((field), (uint64_t)(val)); \
+	} while (0)
+
+static void put_tar_number_impl(char *field, uint64_t val)
 {
 	int i;
 
 	if (val <= USTAR_MAXVAL) {
 		/* octal ASCII; snprintf writes the trailing NUL terminator */
-		snprintf(field, size, "%0*" PRIo64, (int)size - 1, val);
+		snprintf(field, TAR_NUMBER_SIZE, "%0*" PRIo64,
+			 TAR_NUMBER_SIZE - 1, val);
 	} else {
 		/*
 		 * GNU base-256: flag the field with 0x80 in byte 0 and store
@@ -1180,7 +1191,7 @@ static void put_tar_number(char *field, size_t size, uint64_t val)
 		 * unsigned bytes, so the 0x80 flag needs no special handling.
 		 */
 		field[0] = (char)0x80;
-		for (i = (int)size - 1; i >= 1; i--) {
+		for (i = TAR_NUMBER_SIZE - 1; i >= 1; i--) {
 			field[i] = (char)(val & 0xff);
 			val >>= 8;
 		}
@@ -1307,12 +1318,8 @@ static int dump_compressed_tar(struct dump_info *di)
 			numbytes = block_roundup(numbytes);
 		/* dump sparse header */
 		if (i < 4) {
-			put_tar_number(hdr.sparse_map[i].offset,
-				       sizeof(hdr.sparse_map[i].offset),
-				       (uint64_t)offset);
-			put_tar_number(hdr.sparse_map[i].numbytes,
-				       sizeof(hdr.sparse_map[i].numbytes),
-				       (uint64_t)numbytes);
+			put_tar_number(hdr.sparse_map[i].offset, offset);
+			put_tar_number(hdr.sparse_map[i].numbytes, numbytes);
 
 			/* save first extended sparse block for later */
 			if (i == 3)
@@ -1321,13 +1328,11 @@ static int dump_compressed_tar(struct dump_info *di)
 		total_bytes += numbytes;
 	}
 
-	put_tar_number(hdr.numbytes, sizeof(hdr.numbytes),
-		       (uint64_t)total_bytes);
+	put_tar_number(hdr.numbytes, total_bytes);
 
 	if (extended_data)
 		hdr.is_extended = 1;
-	put_tar_number(hdr.filesize, sizeof(hdr.filesize),
-		       (uint64_t)di->core_file_size);
+	put_tar_number(hdr.filesize, di->core_file_size);
 
 	/* calculate checksum */
 	snprintf(hdr.checksum, sizeof(hdr.checksum),
@@ -1355,10 +1360,8 @@ static int dump_compressed_tar(struct dump_info *di)
 			if (next_block)
 				numbytes = block_roundup(numbytes);
 
-			put_tar_number(s.offset, sizeof(s.offset),
-				       (uint64_t)offset);
-			put_tar_number(s.numbytes, sizeof(s.numbytes),
-				       (uint64_t)numbytes);
+			put_tar_number(s.offset, offset);
+			put_tar_number(s.numbytes, numbytes);
 			if (write_file_fd(fd, (char *)&s, sizeof(s)) < 0)
 				goto out;
 			block_bytes_written += sizeof(s);

--- a/src/minicoredumper/corestripper.c
+++ b/src/minicoredumper/corestripper.c
@@ -1151,6 +1151,42 @@ static int dump_zero_block_rest(int fd, size_t block_bytes_written)
 	return dump_zero(fd, rest);
 }
 
+
+/*
+ * ustar stores numeric fields as octal ASCII, right-justified and
+ * zero-padded, with one byte reserved for a NUL (or space) terminator.
+ * A 12-byte field therefore holds 11 octal digits, capping its value at
+ * 077777777777 = 2^33 - 1.
+ */
+#define USTAR_MAXVAL (UINT64_C(077777777777))
+
+/*
+ * Write val into a tar header numeric field of the given size, using ustar
+ * octal encoding when the value fits and GNU tar's base-256 extension
+ * otherwise. Both encodings are understood by "tar x" (GNU tar and
+ * libarchive), including in the old-GNU sparse map.
+ */
+static void put_tar_number(char *field, size_t size, uint64_t val)
+{
+	int i;
+
+	if (val <= USTAR_MAXVAL) {
+		/* octal ASCII; snprintf writes the trailing NUL terminator */
+		snprintf(field, size, "%0*" PRIo64, (int)size - 1, val);
+	} else {
+		/*
+		 * GNU base-256: flag the field with 0x80 in byte 0 and store
+		 * the value big-endian in the rest. get_tar_checksum() sums
+		 * unsigned bytes, so the 0x80 flag needs no special handling.
+		 */
+		field[0] = (char)0x80;
+		for (i = (int)size - 1; i >= 1; i--) {
+			field[i] = (char)(val & 0xff);
+			val >>= 8;
+		}
+	}
+}
+
 static int open_compressor(struct dump_info *di, const char *core_suffix,
 			   char **path)
 {
@@ -1271,12 +1307,12 @@ static int dump_compressed_tar(struct dump_info *di)
 			numbytes = block_roundup(numbytes);
 		/* dump sparse header */
 		if (i < 4) {
-			snprintf(hdr.sparse_map[i].offset,
-				 sizeof(hdr.sparse_map[i].offset),
-				 "%011" PRIo64, offset);
-			snprintf(hdr.sparse_map[i].numbytes,
-				 sizeof(hdr.sparse_map[i].numbytes),
-				 "%011" PRIo64, numbytes);
+			put_tar_number(hdr.sparse_map[i].offset,
+				       sizeof(hdr.sparse_map[i].offset),
+				       (uint64_t)offset);
+			put_tar_number(hdr.sparse_map[i].numbytes,
+				       sizeof(hdr.sparse_map[i].numbytes),
+				       (uint64_t)numbytes);
 
 			/* save first extended sparse block for later */
 			if (i == 3)
@@ -1285,13 +1321,13 @@ static int dump_compressed_tar(struct dump_info *di)
 		total_bytes += numbytes;
 	}
 
-	snprintf(hdr.numbytes, sizeof(hdr.numbytes), "%011" PRIo64,
-		 total_bytes);
+	put_tar_number(hdr.numbytes, sizeof(hdr.numbytes),
+		       (uint64_t)total_bytes);
 
 	if (extended_data)
 		hdr.is_extended = 1;
-	snprintf(hdr.filesize, sizeof(hdr.filesize),
-		 "%011" PRIo64, di->core_file_size);
+	put_tar_number(hdr.filesize, sizeof(hdr.filesize),
+		       (uint64_t)di->core_file_size);
 
 	/* calculate checksum */
 	snprintf(hdr.checksum, sizeof(hdr.checksum),
@@ -1319,10 +1355,10 @@ static int dump_compressed_tar(struct dump_info *di)
 			if (next_block)
 				numbytes = block_roundup(numbytes);
 
-			snprintf(s.offset, sizeof(s.offset), "%011" PRIo64,
-				 offset);
-			snprintf(s.numbytes, sizeof(s.numbytes),
-				 "%011" PRIo64, numbytes);
+			put_tar_number(s.offset, sizeof(s.offset),
+				       (uint64_t)offset);
+			put_tar_number(s.numbytes, sizeof(s.numbytes),
+				       (uint64_t)numbytes);
 			if (write_file_fd(fd, (char *)&s, sizeof(s)) < 0)
 				goto out;
 			block_bytes_written += sizeof(s);


### PR DESCRIPTION
Fixes #6.

I've structured the PR as a revert to the workaround, then the fix the issue, then an optional refactoring to clean up the code, in my opinion.

@jogness In [your comment](https://github.com/diamon/minicoredumper/issues/6#issuecomment-4992434338) you suggested `put_gnu_number` as a more appropriate name. However, we're writing a number in a tar-specific format, which uses different encodings. The function dynamically chooses between ustar's octal and GNU's base-256 encoding, so `put_gnu_number` seems inaccurate to me, and `put_tar_number` seems more fitting. Let me know what you think.

I'm not a C programmer, and I'm not familiar with this project. Let me know if there's anything I can do to improve the code.

I've successfully tested the generation of a core where the logical size would extend beyond 8 GB.